### PR TITLE
Clumsy multiuser user support

### DIFF
--- a/powerdns_auth_proxy/proxy.py
+++ b/powerdns_auth_proxy/proxy.py
@@ -6,7 +6,6 @@ from requests import Request, Session
 from requests.structures import CaseInsensitiveDict
 
 from functools import wraps
-import configparser
 import hmac
 import json
 
@@ -181,7 +180,7 @@ def zone_list():
     """
     if request.method == 'GET':
         try:
-            zones = [zone for zone in json_or_none(proxy_to_backend('GET', 'zones')) if zone['account'] == g.username]
+            zones = [zone for zone in json_or_none(proxy_to_backend('GET', 'zones')) if g.username in zone['account']]
         except TypeError:
             zones = []
         return zones
@@ -205,7 +204,7 @@ def zone_detail(requested_zone):
     DELETE: Delete a zone immediately.
     """
     zone = json_or_none(proxy_to_backend('GET', 'zones/%s' % requested_zone))
-    if zone and zone.get('account', None) != g.username:
+    if zone and g.username not in zone.get('account', None):
         raise Forbidden
 
     if request.method == 'GET': # get metadata
@@ -226,7 +225,7 @@ def zone_notify(requested_zone):
     PUT: Queue a zone for notification to replicas.
     """
     zone = json_or_none(proxy_to_backend('GET', 'zones/%s' % requested_zone))
-    if zone and zone.get('account', None) != g.username:
+    if zone and g.username not in zone.get('account', None):
         raise Forbidden
 
     return proxy_to_backend('PUT', 'zones/%s/notify' % requested_zone, None)


### PR DESCRIPTION
Might be not most elegant way of doing it, but I can see how it will be a problem in future, giving access to 2 separate teams with their users to same zone/domain. Feel free to ignore this request, or edit it.