### PR TITLE
fix syntax error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask~=1.0
-requests~-2.0
+requests~=2.0


### PR DESCRIPTION
installing the dependencies using `pip install -r requirements.txt` (py2.7, 3.6, 3.7) yields the following error on my machine:

```
Invalid requirement: 'requests~-2.0'
(...)
pip._vendor.packaging.requirements.InvalidRequirement: Parse error at "'~-2.0'": Expected stringEnd
```

It seems like there is a small typo, making the parser fail. Fixed it. :)

Thanks for this tool!